### PR TITLE
Optimizations

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,6 +12,7 @@ GEM
       power_assert
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-darwin-21
   x86_64-linux
 


### PR DESCRIPTION
This commit brings a bunch of optimizations to prettier_print, mostly in terms of cutting down on allocations.

Most of the common patterns are now using pre-allocated doc nodes instead of building new ones every time. For nodes that are markers like BreakParent or Trim, there are now instances that correspond to them like BREAK_PARENT and TRIM which are used.

For breakables, we now have methods that encapsulate the most common use cases. These are:

* breakable_space = breakable
* breakable_empty = breakable("")
* breakable_force = breakable("", force: true)
* breakable_return = breakable(" ", indent: false, force: true)

In terms of a couple of breaking changes:

* Trim now strips its whitespace using rstrip! instead of a custom gsub!. This means that other forms of whitespace beyond tabs and spaces are included. This shouldn't really impact anyone unless they're using vertical tab or something in combination with trim nodes and wanted them to stay in.
* There is no longer a PrettierPrint::DefaultBuffer class. Since there were only ever two implementations, those implementations now no longer share a parent.
* PrettierPrint::IndentLevel is now entirely gone. This was mostly an implementation detail, and no one should have been relying on it anyway. However, it means that the ability to use nest with a string literal is now gone as well. It can be created again by using seplist though, so the functionality just isn't there in the shortcut version. This means we're able to keep track of indentation as a single integer again, which drastically simplifies the code.
* Strings can now be added directly to the output buffer, which means they don't have to be placed into the Text node. This cuts down on quite a bit of allocations.

The last optimization is that if_break and if_flat now check if the parent group is already broken. If it is, then they don't bother inserting the content into the final tree. This can cut down on the number of nodes in the final tree by quite a lot.