### PR TITLE
lib/prettier_print: fix minor typo

### DIFF
--- a/lib/prettier_print.rb
+++ b/lib/prettier_print.rb
@@ -214,7 +214,7 @@ class PrettierPrint
   # A node in the print tree that has its own special buffer for implementing
   # content that should flush before any newline.
   #
-  # Useful for implementating trailing content, as it's not always practical to
+  # Useful for implementing trailing content, as it's not always practical to
   # constantly check where the line ends to avoid accidentally printing some
   # content after a line suffix node.
   class LineSuffix


### PR DESCRIPTION
This PR aims to fix a minor typo in the codebase. I noticed this when doing the same review on our Homebrew/brew repo, since we use prettier_print.